### PR TITLE
Add a GitHub Action to run pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: ci
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install --upgrade pip
+      - run: pip install pytest
+      - run: if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - run: pip install --editable . || true
+      - run: pytest || true
+      - run: python run_tests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install --upgrade pip
-      - run: pip install pytest
-      - run: if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - run: pip install pytest -r requirements.txt
       - run: pip install --editable . || true
-      - run: pytest || true
       - run: python run_tests.py
+      - run: pytest || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,7 @@ jobs:
       - run: pip install pytest -r requirements.txt
       - run: pip install --editable . || true
       - run: python run_tests.py
+      - run: pytest --ignore=tests/test_adsb_altitude_decoder.py
+                    --ignore=tests/test_novatel_parser.py
+                    --ignore=tests/test_novatel_passcom_parser.py
       - run: pytest || true


### PR DESCRIPTION
Test results: https://github.com/cclauss/novatel-nav-toolkit/actions

All the custom code in `run_tests.py` ___looks___ cool but does it hide tests, test failures, and test warnings?

Running `run_tests.py` finds and passes 207 tests while just running `pytest`...
```
================= 17 failed, 292 passed, 33 warnings in 24.25s =================
```
---
Even ignoring the three failing files passes while running more tests than `run_tests.py`.
```
% pytest --ignore=tests/test_adsb_altitude_decoder.py \
         --ignore=tests/test_novatel_parser.py \
         --ignore=tests/test_novatel_passcom_parser.py

====================== 251 passed, 33 warnings in 23.63s =======================
```
---
| Command                      | Tests | Failures | Warnings |
|-----------------------------|-----:|--------:|--------:|
| run_tests.py                |    207   |     0     |      0    |
| pytest --ignore=three_files |   251    |    0      |     33     |
| pytest                      |    292   |    17      |    33      |
